### PR TITLE
Fix ECR Login

### DIFF
--- a/v1/travis/ecr-login.sh
+++ b/v1/travis/ecr-login.sh
@@ -18,4 +18,4 @@ pip install --upgrade pip
 pip install awscli
 
 # Login to ECR
-eval $(aws ecr get-login)
+eval $(aws ecr get-login --no-include-email)


### PR DESCRIPTION
@marksost - Travis seems to have updated the default version of docker which breaks the ecr login (see here: https://github.com/awslabs/amazon-ecr-credential-helper/issues/51).

You can see the change in the build logs from a working build about two weeks ago and a failing build today:

WORKING (Docker v17.03): https://api.travis-ci.com/v3/job/99416319/log.txt?log.token=bOVAtcFMgi94khKJ8pS4MQ

BROKEN (Docker v17.09): https://api.travis-ci.com/v3/job/102676760/log.txt?log.token=ghhPmVufz1MOY6zbIw8wMQ

This change will add the --no-include-email. Probably longer term we should download one specific version of docker so travis can't end our world with a single release. I wanted to get this out to unblock the folks working on post office. 