### PR TITLE
Add harness webhook after PR is pushed

### DIFF
--- a/gcr/pr-build.sh
+++ b/gcr/pr-build.sh
@@ -28,6 +28,10 @@ main() {
   docker push $DOCKER_BASE:PR-$TRAVIS_PULL_REQUEST
 
   echo_green "Pushed commit hash image PR-${TRAVIS_PULL_REQUEST} to ${DOCKER_BASE}."
+  
+  if [ -z "$HARNESS_WEBHOOK" ] then
+    curl -X POST -H 'content-type: application/json' --url $HARNESS_WEBHOOK -d '{"application":"${HARNESS_APPLICATION_ID}","artifacts":[{"service":"${HARNESS_SERVICE}","buildNumber":"PR-${TRAVIS_PULL_REQUEST}"}]}'
+  fi
 }
 
 # Function that outputs usage information

--- a/gcr/pr-build.sh
+++ b/gcr/pr-build.sh
@@ -5,7 +5,9 @@
 #   - COMMIT_HASH - The first 7 characters of the travis commit hash
 #   - DOCKER_TAG_BASE - The full URL of the GCR repository (including respository name) to push to
 #                       NOTE: This can be overridden via the -b flag. See usage for more information.
-#
+#   - HARNESS_WEBHOOK - The full webhook URL to trigger a deploy in Harness
+#   - HARNESS_APPLICATION_ID - Harness application ID
+#   - HARNESS_SERVICE - Refers to a service that exists inside Harness. Example "W77"
 # NOTE: Also assumes `gcr-login` has been run in order to successfully log in to GCR
 
 # Set TOOL_ROOT, the location of the directory this script is housed in
@@ -29,8 +31,10 @@ main() {
 
   echo_green "Pushed commit hash image PR-${TRAVIS_PULL_REQUEST} to ${DOCKER_BASE}."
   
-  if [ -z "$HARNESS_WEBHOOK" ] then
-    curl -X POST -H 'content-type: application/json' --url $HARNESS_WEBHOOK -d '{"application":"${HARNESS_APPLICATION_ID}","artifacts":[{"service":"${HARNESS_SERVICE}","buildNumber":"PR-${TRAVIS_PULL_REQUEST}"}]}'
+  if [ -z "$HARNESS_WEBHOOK" ]; then
+    curl -X POST -H 'Content-Type: application/json' \
+    --url "${HARNESS_WEBHOOK}" \
+    -d '{"application":"${HARNESS_APPLICATION_ID}","artifacts":[{"service":"${HARNESS_SERVICE}","buildNumber":"PR-${TRAVIS_PULL_REQUEST}"}]}'
   fi
 }
 

--- a/gcr/pr-build.sh
+++ b/gcr/pr-build.sh
@@ -32,9 +32,13 @@ main() {
   echo_green "Pushed commit hash image PR-${TRAVIS_PULL_REQUEST} to ${DOCKER_BASE}."
   
   if [ -z "$HARNESS_WEBHOOK" ]; then
+    echo_yellow "Letting Harness.io know a PR build happened..."
+
     curl -X POST -H 'Content-Type: application/json' \
     --url "${HARNESS_WEBHOOK}" \
     -d '{"application":"${HARNESS_APPLICATION_ID}","artifacts":[{"service":"${HARNESS_SERVICE}","buildNumber":"PR-${TRAVIS_PULL_REQUEST}"}]}'
+
+    echo_green "Harness.io informed of PR build."
   fi
 }
 


### PR DESCRIPTION
### Jira Ticket(s)

No Ticket

### Description

Adds a curl request which will trigger a harness deploy if the `HARNESS_WEBHOOK` env variable is set in Travis

### Risk/Impact Analysis

Low Risk, code will not run unless Travis is configured.

### QA Notes

N/A