### PR TITLE
PE-2880 - Add webhook for harness to master-build.sh

### DIFF
--- a/gcr/master-build.sh
+++ b/gcr/master-build.sh
@@ -30,6 +30,16 @@ main() {
   docker push $DOCKER_BASE:latest
 
   echo_green "Pushed commit hash image for master to ${DOCKER_BASE}."
+
+  if [ -n "$HARNESS_WEBHOOK_MASTER" ]; then
+    echo_yellow "Letting Harness.io know a master build happened..."
+
+    curl -X POST -H 'Content-Type: application/json' \
+    --url "${HARNESS_WEBHOOK_MASTER}" \
+    -d "{\"application\":\"${HARNESS_APPLICATION_ID}\",\"artifacts\":[{\"service\":\"${HARNESS_SERVICE}\",\"buildNumber\":\"master\"}]}"
+
+    echo_green "\n Harness.io informed of master build."
+  fi  
 }
 
 # Function that outputs usage information


### PR DESCRIPTION
### Jira Ticket(s)

- [PE-2880](https://soulcycle.atlassian.net/browse/PE-2880)

### Description

- Adds webhook to master-build.sh

Delay time will not be needed for master builds as harness will have the artifact in place

### Risk/Impact Analysis

Low

### QA Notes

N/A