### PR TITLE
Remove external link from PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,5 +13,3 @@
 ### QA Notes
 
 <Replace this with any additional information necessary to aid QA in testing the changes>
-
-<See https://soulcycle.atlassian.net/wiki/spaces/DC/pages/527794186/Pull+Request+Description+Details>


### PR DESCRIPTION
### Jira Ticket(s)

- n/a

### Description

Remove external link to Confluence from `PULL_REQUEST_TEMPLATE.md` because it remains visible unless removed

### Risk/Impact Analysis

Minimal impact. No effect on production; only affects the pull request template