### PR TITLE
PE-4834 - Fixes failing ECR builds

### DIFF
--- a/ecr/ecr-login.sh
+++ b/ecr/ecr-login.sh
@@ -15,7 +15,7 @@ sudo chown -R $(whoami) /usr/local
 pip install --upgrade pip
 
 # Install pip dependencies
-pip install awscli
+pip install awscli --ignore-installed urllib3
 
 # Login to ECR
 eval $(aws ecr get-login --no-include-email)


### PR DESCRIPTION
### Jira Ticket(s)

- https://soulcycle.atlassian.net/browse/PE-4834

### Description

This issue occurred due to Travis running pip 10, which has issues with previously-installed packages. We're ignoring the package that was causing an issue