### PR TITLE
PE-10193 Add Jira Ticket Numbers to Harness Webhook

### DIFF
--- a/gcr/semver-build.sh
+++ b/gcr/semver-build.sh
@@ -31,12 +31,17 @@ main() {
 
   echo_green "Pushed commit hash image for a semver tag to ${DOCKER_BASE}."
 
+  # Parse out JIRA Tickets to send to Harness
+  PREVIOUS_TAG=$(git describe --abbrev=0 --tags `git rev-list --tags --skip=1 --max-count=1`)
+  PATTERN="PE-[[:digit:]]*"
+  JIRA_TICKETS=[$(git diff ${PREVIOUS_TAG} -- CHANGELOG.md | grep -o ${PATTERN})]
+
   if [ -n "$HARNESS_WEBHOOK_SEMVER" ]; then
     echo_yellow "Letting Harness.io know a semver build happened..."
 
     curl -X POST -H 'Content-Type: application/json' \
     --url "${HARNESS_WEBHOOK_SEMVER}" \
-    -d "{\"application\":\"${HARNESS_APPLICATION_ID}\",\"artifacts\":[{\"service\":\"${HARNESS_SERVICE}\",\"buildNumber\":\"${TRAVIS_TAG}\"}]}"
+    -d "{\"application\":\"${HARNESS_APPLICATION_ID}\",\"artifacts\":[{\"service\":\"${HARNESS_SERVICE}\",\"buildNumber\":\"${TRAVIS_TAG}\",\"jiraTickets\":\"${JIRA_TICKETS}\"}]}"
 
     echo_green "\n Harness.io informed of semver build."
   fi


### PR DESCRIPTION
### Jira Ticket(s)

- [PE-10193](https://soulcycle.atlassian.net/browse/PE-10193)

### Description

Add JIRA Ticket Numbers to Harness Webhook on release so that when a release succesfully deploys to production the JIRA Ticket Status can be updated to Closed

### Risk/Impact Analysis

Medium - Not sure how to test this to make sure `git` commands work in the build environment. I tested the scripts locally and they are returning the proper data completely parsed out.

### QA Notes

N/A